### PR TITLE
feat: check working tree and abort if not clean

### DIFF
--- a/lib-release.js
+++ b/lib-release.js
@@ -89,6 +89,21 @@ console.log(chalk.cyan(outdent`
   `));
 
 promiseSeries([
+  () => execaPipeError('git diff --exit-code --quiet HEAD')
+    .then(({ stdout }) => stdout)
+    .catch((reason) => {
+      console.log(chalk.red(outdent`
+
+        Attention: Your working tree is not clean. I will abort the action
+
+        Please check your working tree:
+
+        ${chalk.bold('git status')}
+
+      `));
+
+      throw reason;
+    }),
   () => execaPipeError('npm whoami')
     .then(({ stdout }) => stdout)
     .catch((reason) => {


### PR DESCRIPTION
fix #35 

This automatically aborts the release, if the working tree isn't clean.

Running `node ./lib-release.js` with **uncommited changes**:

```sh

🚀  Hello Dear developer, welcome to the release assistant. 🚀

!! Please make sure you have no changes to be commited !!

I'm getting some information....

>>> rejected | git diff --exit-code --quiet HEAD

Attention: Your working tree is not clean. I will abort the action

Please check your working tree:

git status
```

Running `node ./lib-release.js` with **staged changes**:

```sh

🚀  Hello Dear developer, welcome to the release assistant. 🚀

!! Please make sure you have no changes to be commited !!

I'm getting some information....

>>> rejected | git diff --exit-code --quiet HEAD

Attention: Your working tree is not clean. I will abort the action

Please check your working tree:

git status
```